### PR TITLE
fix hashmap get_from_bucket() wrong return type

### DIFF
--- a/examples/hashmap_example.c
+++ b/examples/hashmap_example.c
@@ -30,7 +30,8 @@ void stress_test()
 
 int main()
 {
-    stress_test();
+    /* puts and later gets a bunch of entries in a hashmap */
+    //stress_test();
 
     struct hashmap_t map;
     hashmap_init(&map);
@@ -42,14 +43,28 @@ int main()
     char *a = "hello";
     hashmap_put(&map, a, strlen(a) + 1, &x, 1);
     char *b = "hellO";
-    hashmap_put(&map, b, strlen(b) + 1, &y, 1);
+    hashmap_sput(&map, b, &y, 1);
     char *c = "hello.";
-    hashmap_put(&map, c, strlen(c) + 1, &z, 1);
+    hashmap_sput(&map, c, &z, 1);
 
     int *X = hashmap_get(&map, a, strlen(a) + 1);
     int *Y = hashmap_get(&map, b, strlen(b) + 1);
-    int *Z = hashmap_get(&map, c, strlen(c) + 1);
+    int *Z = hashmap_sget(&map, c);
     assert(*X == x && *Y == y && *Z == z);
+
+    assert(hashmap_len(&map) == 3);
+    bool rc;
+    /* removing an item */
+    rc = hashmap_rm(&map, a, strlen(a) + 1);
+    assert(rc == true);
+    assert(hashmap_len(&map) == 2);
+
+    /* removing an item that is already removed */
+    rc = hashmap_rm(&map, a, strlen(a) + 1);
+    assert(rc == false);
+    X = hashmap_sget(&map, a);
+    assert(X == NULL);
+    assert(hashmap_len(&map) == 2);
 
     hashmap_free(&map);
 }

--- a/hashmap.h
+++ b/hashmap.h
@@ -17,7 +17,7 @@
 
 
 struct hashmap_entry_t {
-    void *value;
+    void *value;                // if NULL then entry is marked as unused
     void *key;
     size_t key_size;
     uint8_t hash_extra;         // used for faster comparison
@@ -51,9 +51,15 @@ void hashmap_init(struct hashmap_t *map);
 void hashmap_free(struct hashmap_t *map);
 
 void hashmap_put(struct hashmap_t *map, void *key, size_t key_size, void *t, size_t ts);
+#define hashmap_sput(a, b, c, d) hashmap_put(a, b, (strlen(b) + 1) * sizeof(char), c, d)
+#define hashmap_ssput(a, b, c) hashmap_put(a, b, (strlen(b) + 1) * sizeof(char), c, (strlen(c) + 1) * sizeof(char))
 
 void *hashmap_get(struct hashmap_t *map, void *key, size_t key_size);
+#define hashmap_sget(a, b) hashmap_get(a, b, (strlen(b) + 1) * sizeof(char))
 
 bool hashmap_rm(struct hashmap_t *map, void *key, size_t key_size);
+#define hashmap_srm(a, b) hashmap_rm(a, b, (strlen(b) + 1) * sizeof(char))
+
+size_t hashmap_len(struct hashmap_t *map);
 
 #endif /* HASHMAP_H */


### PR DESCRIPTION
Man.

```c
struct hashmap_entry_t {
    void *value;                // if NULL then entry is marked as unused
    void *key;
    size_t key_size;
    uint8_t hash_extra;         // used for faster comparison
                                // the common case is that the bytes are not equal
};
```

So when you return a pointer to a struct, essentially all you do (leaving out some details here) is returning a pointer to the first member of the struct. The function get_from_bucket() returned the struct member value of a hashmap_entry_t. This is coincidentally the first member of the struct. In the function that called get_from_bucket() I assumed it returned the entire struct object, not just the value member. But, as it turns out, this bug is extremely difficult to notice, since the compiler has no issue casting the pointer to a hashmap_entry_t, since the pointer it returns would be the same if it just returned the struct and not the value member... Crazy!